### PR TITLE
Update server.cfg.sample

### DIFF
--- a/cfg/server.cfg.sample
+++ b/cfg/server.cfg.sample
@@ -1,5 +1,5 @@
 [server]
-ardb_port = 16379
+ardb_port = 6666
 ardb_socket = /tmp/ardb.sock
 api_key = afdef83f9cc7c87b801c36e4af632ef06af2f2ef
 default_source = unknown


### PR DESCRIPTION
just change to port `6666` on localhost. Because kvrocks  use it.

Not really sure if its good fix. Hope will help when you use kvrocks.